### PR TITLE
Add simple integ test for CassandraDatacenter controller

### DIFF
--- a/controllers/cassandradatacenter_controller.go
+++ b/controllers/cassandradatacenter_controller.go
@@ -119,6 +119,7 @@ func (r *CassandraDatacenterReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 		// Include the namespace in case Reaper is deployed in a different namespace than
 		// the CassandraDatacenter.
 		reaperSvc := reaper.Name + "-reaper-service" + "." + reaper.Namespace
+
 		restClient, err := reapergo.NewReaperClient(fmt.Sprintf("http://%s:8080", reaperSvc))
 		if err != nil {
 			r.Log.Error(err, "failed to create reaper rest client", "reaperService", reaperSvc)
@@ -153,6 +154,9 @@ func (r *CassandraDatacenterReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 				return ctrl.Result{RequeueAfter: shortDelay}, err
 			}
 		}
+
+		r.Log.Error(err, "failed to get cluster", "reaper", reaperKey)
+		return ctrl.Result{RequeueAfter: shortDelay}, err
 	}
 
 	// The CassandraDatacenter does not have the annotation which means it is not using

--- a/controllers/cassandradatacenter_controller_test.go
+++ b/controllers/cassandradatacenter_controller_test.go
@@ -55,15 +55,6 @@ var _ = Describe("CassandraDatacenter controller testing", func() {
 				ServerVersion: "3.11.7",
 				Size:          3,
 			},
-			Status: cassdcapi.CassandraDatacenterStatus{
-				CassandraOperatorProgress: cassdcapi.ProgressReady,
-				Conditions: []cassdcapi.DatacenterCondition{
-					{
-						Status: corev1.ConditionTrue,
-						Type:   cassdcapi.DatacenterReady,
-					},
-				},
-			},
 		}
 		Expect(k8sClient.Create(context.Background(), testDc)).Should(Succeed())
 		Eventually(func() bool {

--- a/controllers/cassandradatacenter_controller_test.go
+++ b/controllers/cassandradatacenter_controller_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	CassandraDatacenterName = "dc1"
-	ControllerTestNamespace = "dc-test"
+	CassandraControllerDatacenterName = "dc1"
+	ControllerTestNamespace           = "dc-test"
 )
 
 var _ = Describe("CassandraDatacenter controller testing", func() {
@@ -39,7 +39,7 @@ var _ = Describe("CassandraDatacenter controller testing", func() {
 		Expect(k8sClient.Create(context.Background(), reaper)).Should(Succeed())
 
 		cassdcKey := types.NamespacedName{
-			Name:      CassandraDatacenterName,
+			Name:      CassandraControllerDatacenterName,
 			Namespace: ControllerTestNamespace,
 		}
 

--- a/controllers/cassandradatacenter_controller_test.go
+++ b/controllers/cassandradatacenter_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	cassdcapi "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	api "github.com/k8ssandra/reaper-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -67,3 +68,18 @@ var _ = Describe("Verify functionality of CassandraDatacenterReconciler", func()
 		verifyReaperReady(types.NamespacedName{Namespace: ControllerTestNamespace, Name: ReaperName})
 	})
 })
+
+type TestReaperManager struct {
+}
+
+func (r *TestReaperManager) Connect(reaper *api.Reaper) error {
+	return nil
+}
+
+func (r *TestReaperManager) AddClusterToReaper(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) error {
+	return nil
+}
+
+func (r *TestReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) (bool, error) {
+	return true, nil
+}

--- a/controllers/cassandradatacenter_controller_test.go
+++ b/controllers/cassandradatacenter_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	cassdcapi "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/reaper-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -17,8 +18,17 @@ const (
 	ControllerTestNamespace = "dc-test"
 )
 
-var _ = Describe("Verify functionality of CassandraDatacenterReconciler", func() {
-	Specify("..", func() {
+var _ = Describe("CassandraDatacenter controller testing", func() {
+	BeforeEach(func() {
+		// Add any setup steps that needs to be executed before each test
+	})
+
+	AfterEach(func() {
+		// Add any teardown steps that needs to be executed after each test
+	})
+
+	It("checking Reaper cluster status", func() {
+		By("expecting CassandraDatacenter creation")
 		testNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: ControllerTestNamespace,
@@ -28,13 +38,16 @@ var _ = Describe("Verify functionality of CassandraDatacenterReconciler", func()
 		reaper := createReaper(ControllerTestNamespace)
 		Expect(k8sClient.Create(context.Background(), reaper)).Should(Succeed())
 
+		cassdcKey := types.NamespacedName{
+			Name:      CassandraDatacenterName,
+			Namespace: ControllerTestNamespace,
+		}
+
 		testDc := &cassdcapi.CassandraDatacenter{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      CassandraDatacenterName,
-				Namespace: ControllerTestNamespace,
-				Annotations: map[string]string{
-					"reaper.cassandra-reaper.io/instance": "notHere",
-				},
+				Name:        cassdcKey.Name,
+				Namespace:   cassdcKey.Namespace,
+				Annotations: map[string]string{},
 			},
 			Spec: cassdcapi.CassandraDatacenterSpec{
 				ClusterName:   "test-dc",
@@ -53,33 +66,160 @@ var _ = Describe("Verify functionality of CassandraDatacenterReconciler", func()
 			},
 		}
 		Expect(k8sClient.Create(context.Background(), testDc)).Should(Succeed())
+		Eventually(func() bool {
+			result := &cassdcapi.CassandraDatacenter{}
+			_ = k8sClient.Get(context.Background(), cassdcKey, result)
+			return result.Spec.Size == testDc.Spec.Size
+		}, timeout, interval).Should(BeTrue())
 
-		By("update annotation to target existing reaper instance")
+		By("making Reaper ready")
+		patch := client.MergeFrom(reaper.DeepCopy())
+		reaper.Status.Ready = true
+		k8sClient.Status().Patch(context.Background(), reaper, patch)
+		verifyReaperReady(types.NamespacedName{Namespace: ControllerTestNamespace, Name: ReaperName})
+
+		By("verifying reaper is not targeting the CassandraDatacenter")
+		Consistently(func() bool {
+			if len(reaperManager.ClustersManaged) > 0 {
+				return false
+			}
+
+			key := types.NamespacedName{Namespace: reaper.Namespace, Name: ReaperName}
+			fetchedReaper := &api.Reaper{}
+			if err := k8sClient.Get(context.Background(), key, fetchedReaper); err != nil {
+				return false
+			}
+			return len(fetchedReaper.Status.Clusters) == 0
+		}, timeout, interval).Should(BeTrue())
+
+		By("updating reaper annotation to point to non-existing reaper instance")
 		testDcPatch := client.MergeFrom(testDc.DeepCopy())
+		testDc.Annotations = map[string]string{
+			"reaper.cassandra-reaper.io/instance": "notHere",
+		}
+		Expect(k8sClient.Patch(context.Background(), testDc, testDcPatch)).Should(Succeed())
+		Eventually(func() bool {
+			result := &cassdcapi.CassandraDatacenter{}
+			_ = k8sClient.Get(context.Background(), cassdcKey, result)
+			v, _ := result.Annotations["reaper.cassandra-reaper.io/instance"]
+			return v == "notHere"
+		}).Should(BeTrue())
+
+		By("verifying reaper is still not targeting the CassandraDatacenter")
+		Consistently(func() bool {
+			if len(reaperManager.ClustersManaged) > 0 || len(reaperManager.ClustersManaged) > 0 {
+				return false
+			}
+
+			key := types.NamespacedName{Namespace: reaper.Namespace, Name: ReaperName}
+			fetchedReaper := &api.Reaper{}
+			if err := k8sClient.Get(context.Background(), key, fetchedReaper); err != nil {
+				return false
+			}
+			return len(fetchedReaper.Status.Clusters) == 0
+		}, timeout, interval).Should(BeTrue())
+
+		By("updating annotation to target working reaper instance")
+		testDcPatch = client.MergeFrom(testDc.DeepCopy())
 		testDc.Annotations = map[string]string{
 			"reaper.cassandra-reaper.io/instance": reaper.Name,
 		}
 		Expect(k8sClient.Patch(context.Background(), testDc, testDcPatch)).Should(Succeed())
+		Eventually(func() bool {
+			result := &cassdcapi.CassandraDatacenter{}
+			_ = k8sClient.Get(context.Background(), cassdcKey, result)
+			v, _ := result.Annotations["reaper.cassandra-reaper.io/instance"]
+			return v == reaper.Name
+		}, timeout, interval).Should(BeTrue())
 
-		By("make Reaper ready")
-		reaper.Status.Ready = true
-		reaper.Status.Clusters = append(reaper.Status.Clusters, "test-dc")
-		k8sClient.Status().Update(context.Background(), reaper)
-		verifyReaperReady(types.NamespacedName{Namespace: ControllerTestNamespace, Name: ReaperName})
+		By("verifying reaper is now targeting the CassandraDatacenter, but fails")
+		reaperManager.failMode = true
+		Consistently(func() bool {
+			key := types.NamespacedName{Namespace: reaper.Namespace, Name: ReaperName}
+			fetchedReaper := &api.Reaper{}
+			if err := k8sClient.Get(context.Background(), key, fetchedReaper); err != nil {
+				return false
+			}
+			if len(fetchedReaper.Status.Clusters) == 0 && len(reaperManager.ClustersManaged) == 0 {
+				return true
+			}
+
+			return false
+		}, timeout, interval).Should(BeTrue())
+
+		By("letting reaper succeed with the cluster adding")
+		reaperManager.failMode = false
+		Eventually(func() bool {
+			key := types.NamespacedName{Namespace: reaper.Namespace, Name: ReaperName}
+			fetchedReaper := &api.Reaper{}
+			if err := k8sClient.Get(context.Background(), key, fetchedReaper); err != nil {
+				return false
+			}
+			for _, v := range fetchedReaper.Status.Clusters {
+				if v == testDc.Spec.ClusterName {
+					// Verify Reaper knows it also
+					for _, d := range reaperManager.ClustersManaged {
+						if d == testDc.Spec.ClusterName {
+							return true
+						}
+					}
+					return false
+				}
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
+
+		By("ensuring cluster status is re-added even if removed")
+		// Remove cluster status from reaper
+		patchClusters := client.MergeFrom(reaper.DeepCopy())
+		reaper.Status.Clusters = make([]string, 0)
+		k8sClient.Status().Patch(context.Background(), reaper, patchClusters)
+
+		// Add unnecessary stuff to CassandraDatacenter to trigger reconcile
+		testDcPatch = client.MergeFrom(testDc.DeepCopy())
+		testDc.Annotations["useless/update"] = "true"
+		Expect(k8sClient.Patch(context.Background(), testDc, testDcPatch)).Should(Succeed())
+
+		// Wait for the cluster to be re-added
+		Eventually(func() bool {
+			key := types.NamespacedName{Namespace: reaper.Namespace, Name: ReaperName}
+			fetchedReaper := &api.Reaper{}
+			if err := k8sClient.Get(context.Background(), key, fetchedReaper); err != nil {
+				return false
+			}
+			for _, v := range fetchedReaper.Status.Clusters {
+				if v == testDc.Spec.ClusterName {
+					return true
+				}
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
 	})
 })
 
 type TestReaperManager struct {
+	ClustersManaged []string
+	failMode        bool
 }
 
 func (r *TestReaperManager) Connect(reaper *api.Reaper) error {
+	r.ClustersManaged = make([]string, 0)
 	return nil
 }
 
 func (r *TestReaperManager) AddClusterToReaper(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) error {
+	if r.failMode {
+		return fmt.Errorf("mocked failure of cluster adding")
+	}
+	r.ClustersManaged = append(r.ClustersManaged, cassdc.Spec.ClusterName)
 	return nil
 }
 
 func (r *TestReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) (bool, error) {
-	return true, nil
+	for _, v := range r.ClustersManaged {
+		if v == cassdc.Spec.ClusterName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/controllers/cassandradatacenter_controller_test.go
+++ b/controllers/cassandradatacenter_controller_test.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"context"
+	cassdcapi "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CassandraDatacenterName = "dc1"
+	ControllerTestNamespace = "dc-test"
+)
+
+var _ = Describe("Verify functionality of CassandraDatacenterReconciler", func() {
+	Specify("..", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ControllerTestNamespace,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), testNamespace)).Should(Succeed())
+		reaper := createReaper(ControllerTestNamespace)
+		Expect(k8sClient.Create(context.Background(), reaper)).Should(Succeed())
+
+		testDc := &cassdcapi.CassandraDatacenter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      CassandraDatacenterName,
+				Namespace: ControllerTestNamespace,
+				Annotations: map[string]string{
+					"reaper.cassandra-reaper.io/instance": "notHere",
+				},
+			},
+			Spec: cassdcapi.CassandraDatacenterSpec{
+				ClusterName:   "test-dc",
+				ServerType:    "cassandra",
+				ServerVersion: "3.11.7",
+				Size:          3,
+			},
+			Status: cassdcapi.CassandraDatacenterStatus{
+				CassandraOperatorProgress: cassdcapi.ProgressReady,
+				Conditions: []cassdcapi.DatacenterCondition{
+					{
+						Status: corev1.ConditionTrue,
+						Type:   cassdcapi.DatacenterReady,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), testDc)).Should(Succeed())
+
+		By("update annotation to target existing reaper instance")
+		testDcPatch := client.MergeFrom(testDc.DeepCopy())
+		testDc.Annotations = map[string]string{
+			"reaper.cassandra-reaper.io/instance": reaper.Name,
+		}
+		Expect(k8sClient.Patch(context.Background(), testDc, testDcPatch)).Should(Succeed())
+
+		By("make Reaper ready")
+		reaper.Status.Ready = true
+		reaper.Status.Clusters = append(reaper.Status.Clusters, "test-dc")
+		k8sClient.Status().Update(context.Background(), reaper)
+		verifyReaperReady(types.NamespacedName{Namespace: ControllerTestNamespace, Name: ReaperName})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -101,8 +101,9 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&CassandraDatacenterReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		Client:        k8sManager.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		ReaperManager: &TestReaperManager{},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -100,6 +100,12 @@ var _ = BeforeSuite(func(done Done) {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&CassandraDatacenterReconciler{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		err = k8sManager.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -47,6 +47,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var reaperManager *TestReaperManager
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -100,10 +101,12 @@ var _ = BeforeSuite(func(done Done) {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	reaperManager = &TestReaperManager{}
+
 	err = (&CassandraDatacenterReconciler{
 		Client:        k8sManager.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
-		ReaperManager: &TestReaperManager{},
+		ReaperManager: reaperManager,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/k8ssandra/reaper-operator/pkg/config"
+	reapermanager "github.com/k8ssandra/reaper-operator/pkg/reaper"
 	"github.com/k8ssandra/reaper-operator/pkg/reconcile"
 
 	cassdcv1beta1 "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
@@ -95,9 +96,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.CassandraDatacenterReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
-		Scheme: mgr.GetScheme(),
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		Scheme:        mgr.GetScheme(),
+		ReaperManager: &reapermanager.RestReaperManager{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraDatacenter")
 		os.Exit(1)

--- a/pkg/reaper/manager.go
+++ b/pkg/reaper/manager.go
@@ -1,0 +1,50 @@
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/reaper-client-go/reaper"
+	reapergo "github.com/k8ssandra/reaper-client-go/reaper"
+	api "github.com/k8ssandra/reaper-operator/api/v1alpha1"
+)
+
+type ReaperManager interface {
+	Connect(reaper *api.Reaper) error
+	AddClusterToReaper(ctx context.Context, cassdc *v1beta1.CassandraDatacenter) error
+	VerifyClusterIsConfigured(ctx context.Context, cassdc *v1beta1.CassandraDatacenter) (bool, error)
+}
+
+// RestReaperManager abstracts the ugly details of how to connect to the Reaper instance
+type RestReaperManager struct {
+	reaperClient reaper.ReaperClient
+}
+
+func (r *RestReaperManager) Connect(reaper *api.Reaper) error {
+	// Include the namespace in case Reaper is deployed in a different namespace than
+	// the CassandraDatacenter.
+	reaperSvc := reaper.Name + "-reaper-service" + "." + reaper.Namespace
+
+	reaperClient, err := reapergo.NewReaperClient(fmt.Sprintf("http://%s:8080", reaperSvc))
+	if err != nil {
+		return err
+	}
+	r.reaperClient = reaperClient
+	return nil
+}
+
+func (r *RestReaperManager) AddClusterToReaper(ctx context.Context, cassdc *v1beta1.CassandraDatacenter) error {
+	return r.reaperClient.AddCluster(ctx, cassdc.Spec.ClusterName, cassdc.GetDatacenterServiceName())
+}
+
+func (r *RestReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *v1beta1.CassandraDatacenter) (bool, error) {
+	_, err := r.reaperClient.GetCluster(ctx, cassdc.Spec.ClusterName)
+	if err != nil {
+		if err == reaper.CassandraClusterNotFound {
+			// We didn't have issues verifying the existence, but the cluster isn't there
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
The testing process stops when reapergo client is used in the controller as it can't be reached. Also, add logging to that error case. Issue #9 