### PR TITLE
Add schema migration init container [K8SSAND-625]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,10 +86,12 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Kind kube-proxy issue workaround
+        run: sudo sysctl net/netfilter/nf_conntrack_max=524288
       - name: Create Kind Cluster
         uses: helm/kind-action@v1.1.0
         with:
-          version: v0.10.0
+          version: v0.11.1
           node_image: kindest/node:v1.20.2
           cluster_name: kind
           config: test/config/kind/kind_config_3_workers.yaml

--- a/api/v1alpha1/reaper_types.go
+++ b/api/v1alpha1/reaper_types.go
@@ -27,7 +27,7 @@ import (
 type StorageType string
 
 const (
-	DefaultReaperImage     = "thelastpickle/cassandra-reaper:2.2.1"
+	DefaultReaperImage     = "thelastpickle/cassandra-reaper:2.3.0"
 	DefaultImagePullPolicy = corev1.PullIfNotPresent
 
 	StorageTypeMemory    = StorageType("memory")

--- a/pkg/reconcile/reconcilers_test.go
+++ b/pkg/reconcile/reconcilers_test.go
@@ -100,6 +100,36 @@ func TestNewDeployment(t *testing.T) {
 		},
 	})
 
+	assert.Equal(1, len(podSpec.InitContainers))
+
+	initContainer := podSpec.InitContainers[0]
+	assert.Equal(image, initContainer.Image)
+	assert.Equal(corev1.PullAlways, initContainer.ImagePullPolicy)
+	assert.ElementsMatch(initContainer.Env, []corev1.EnvVar{
+		{
+			Name:  "REAPER_STORAGE_TYPE",
+			Value: "cassandra",
+		},
+		{
+			Name:  "REAPER_ENABLE_DYNAMIC_SEED_LIST",
+			Value: "false",
+		},
+		{
+			Name:  "REAPER_CASS_CONTACT_POINTS",
+			Value: "[target-datacenter-service]",
+		},
+		{
+			Name:  "REAPER_AUTH_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "REAPER_AUTO_SCHEDULING_ENABLED",
+			Value: "true",
+		},
+	})
+
+	assert.ElementsMatch(initContainer.Args, []string{"schema-migration"})
+
 	reaper.Spec.ServerConfig.AutoScheduling = &api.AutoScheduler{
 		Enabled:              false,
 		InitialDelay:         "PT10S",

--- a/test/config/reaper/bases/reaper.yaml
+++ b/test/config/reaper/bases/reaper.yaml
@@ -3,7 +3,7 @@ kind: Reaper
 metadata:
   name: reaper-test
 spec:
-  image: docker.io/thelastpickle/cassandra-reaper:2.2.5
+  image: docker.io/thelastpickle/cassandra-reaper:2.3.0
   serverConfig:
     storageType: cassandra
     jmxUserSecretName: reaper-jmx


### PR DESCRIPTION
This PR requires Reaper [PR 1096](https://github.com/thelastpickle/cassandra-reaper/pull/1096) to be merged and released first.

Fixes #56 

This change adds an init container that will start Reaper in schema migration only mode, allowing for it to pass without probes that could trigger a restart mid-migration.