### PR TITLE
Miles/deployment strategy recreate [K8SSAND-816]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PROJECT=reaper-operator
 REG?=docker.io
 
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-REV=$(shell git rev-parse --short=12 HEAD)
+REV=$(shell git rev-parse --short=8 HEAD)
 
 IMAGE_BASE=$(REG)/$(ORG)/$(PROJECT)
 REV_IMAGE=$(IMAGE_BASE):$(REV)

--- a/controllers/reaper_controller_test.go
+++ b/controllers/reaper_controller_test.go
@@ -149,35 +149,60 @@ var _ = Describe("Reaper controller", func() {
 
 		By("check that the deployment is created")
 		deploymentKey := types.NamespacedName{Namespace: ReaperNamespace, Name: ReaperName}
-		deployment := &appsv1.Deployment{}
+		currentDeployment := &appsv1.Deployment{}
 
 		Eventually(func() error {
-			return k8sClient.Get(context.Background(), deploymentKey, deployment)
+			return k8sClient.Get(context.Background(), deploymentKey, currentDeployment)
 		}, timeout, interval).Should(Succeed(), "deployment creation check failed")
 
-		Expect(len(deployment.OwnerReferences)).Should(Equal(1), "deployment owner reference not set")
-		Expect(deployment.OwnerReferences[0].UID).Should(Equal(reaper.GetUID()), "deployment owner reference has wrong uid")
+		Expect(len(currentDeployment.OwnerReferences)).Should(Equal(1), "deployment owner reference not set")
+		Expect(currentDeployment.OwnerReferences[0].UID).Should(Equal(reaper.GetUID()), "deployment owner reference has wrong uid")
 
 		By("update deployment to be ready")
-		patchDeploymentStatus(deployment, 1, 1)
+		patchDeploymentStatus(currentDeployment, 1, 1)
 
 		verifyReaperReady(types.NamespacedName{Namespace: ReaperNamespace, Name: ReaperName})
+
+		// Simulate changing the deployment strategy to rolling.
+		// The deployment strategy should be reconciled back to recreate.
+		By("patch deployment to have a rolling update strategy")
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), deploymentKey, currentDeployment)
+		}, timeout, interval).Should(Succeed(), "could not obtain current deployment")
+		deploymentPatch := client.MergeFrom(currentDeployment.DeepCopy())
+		currentDeployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+		}
+		if err := k8sClient.Patch(context.Background(), currentDeployment, deploymentPatch); err != nil {
+			Fail("Failed to patch deployment with appsv1.RecreateDeploymentStrategyType")
+		}
+		Eventually(func() bool {
+			if err := k8sClient.Get(context.Background(), deploymentKey, currentDeployment); err != nil {
+				Fail("lost the reaper deployment")
+			}
+			return currentDeployment.Spec.Strategy.Type == appsv1.RollingUpdateDeploymentStrategyType
+		}, timeout, interval).Should(BeTrue(), "deployment strategy type should have been patched to rolling")
+		Eventually(func() bool {
+			if err := k8sClient.Get(context.Background(), deploymentKey, currentDeployment); err != nil {
+				Fail("lost the reaper deployment")
+			}
+			return currentDeployment.Spec.Strategy.Type == appsv1.RecreateDeploymentStrategyType
+		}, timeout, interval).Should(BeTrue(), "deployment strategy type should have been reconciled back to recreate")
 
 		// Now simulate the Reaper app entering a state in which its readiness probe fails. This
 		// should cause the deployment to have its status updated. The Reaper object's .Status.Ready
 		// field should subsequently be updated.
 		By("update deployment to be not ready")
-		patchDeploymentStatus(deployment, 1, 0)
-
 		reaperKey := types.NamespacedName{Namespace: ReaperNamespace, Name: ReaperName}
-		updatedReaper := &api.Reaper{}
+		currentReaper := &api.Reaper{}
+		patchDeploymentStatus(currentDeployment, 1, 0)
 		Eventually(func() bool {
-			err := k8sClient.Get(context.Background(), reaperKey, updatedReaper)
+			err := k8sClient.Get(context.Background(), reaperKey, currentReaper)
 			if err != nil {
 				return false
 			}
-			ctrl.Log.WithName("test").Info("after update", "updatedReaper", updatedReaper)
-			return updatedReaper.Status.Ready == false
+			ctrl.Log.WithName("test").Info("after update", "updatedReaper", currentReaper)
+			return currentReaper.Status.Ready == false
 		}, timeout, interval).Should(BeTrue(), "reaper status should have been updated")
 	})
 

--- a/controllers/reaper_controller_test.go
+++ b/controllers/reaper_controller_test.go
@@ -24,7 +24,7 @@ const (
 	ReaperName              = "test-reaper"
 	CassandraDatacenterName = "test-dc"
 
-	timeout  = time.Second * 10
+	timeout  = time.Second * 20
 	interval = time.Millisecond * 250
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
-	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/client-go v0.21.4
 	k8s.io/kubernetes v1.21.4
 	sigs.k8s.io/controller-runtime v0.9.2
 )

--- a/pkg/reconcile/reconcilers.go
+++ b/pkg/reconcile/reconcilers.go
@@ -286,6 +286,20 @@ func (r *defaultReconciler) ReconcileDeployment(ctx context.Context, req ReaperR
 			return &ctrl.Result{RequeueAfter: 10 * time.Second}, err
 		}
 	} else {
+		if deployment.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
+			// When strategy is not set to RecreateDeploymentStrategyType this can cause [issues](https://github.com/k8ssandra/reaper-operator/issues/63) where multiple Reaper pods exist concurrently.
+			// This is not supported due to the way that migrations in Reaper work. We need to ensure that RecreateDeploymentStrategyType is in place before any upgrades can occur.
+			req.Logger.Info("Reaper deployment not currently using appsv1.RecreateDeploymentStrategyType, patching and re-queueing the request")
+			patch := client.StrategicMergeFrom(deployment.DeepCopy())
+			deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			}
+			if err := r.Patch(ctx, deployment, patch); err != nil {
+				req.Logger.Error(err, "Failed to patch deployment with appsv1.RecreateDeploymentStrategyType")
+				return &ctrl.Result{RequeueAfter: 10 * time.Second}, err
+			}
+			return &ctrl.Result{RequeueAfter: 10 * time.Second}, err
+		}
 		if !util.ResourcesHaveSameHash(desiredDeployment, deployment) {
 			req.Logger.Info("updating deployment", "deployment", key)
 

--- a/pkg/reconcile/reconcilers.go
+++ b/pkg/reconcile/reconcilers.go
@@ -501,6 +501,9 @@ func newDeployment(reaper *api.Reaper, cassDcService string) *appsv1.Deployment 
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &selector,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/reconcile/reconcilers_test.go
+++ b/pkg/reconcile/reconcilers_test.go
@@ -1,19 +1,27 @@
 package reconcile
 
 import (
+	"context"
 	"testing"
 
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/reaper-operator/api/v1alpha1"
 	mlabels "github.com/k8ssandra/reaper-operator/pkg/labels"
+	"github.com/k8ssandra/reaper-operator/pkg/status"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestNewService(t *testing.T) {
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	key := types.NamespacedName{Namespace: reaper.Namespace, Name: GetServiceName(reaper.Name)}
 
 	service := newService(key, reaper)
@@ -40,7 +48,7 @@ func TestNewService(t *testing.T) {
 func TestNewDeployment(t *testing.T) {
 	assert := assert.New(t)
 	image := "test/reaper:latest"
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.ImagePullPolicy = "Always"
 	reaper.Spec.ServerConfig.AutoScheduling = &api.AutoScheduler{Enabled: true}
@@ -208,7 +216,7 @@ func TestTolerations(t *testing.T) {
 		},
 	}
 
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.Tolerations = tolerations
 
@@ -236,7 +244,7 @@ func TestAffinity(t *testing.T) {
 			},
 		},
 	}
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.Affinity = affinity
 
@@ -252,7 +260,7 @@ func TestContainerSecurityContext(t *testing.T) {
 	securityContext := &corev1.SecurityContext{
 		ReadOnlyRootFilesystem: &readOnlyRootFilesystemOverride,
 	}
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.SecurityContext = securityContext
 
@@ -276,7 +284,7 @@ func TestSchemaInitContainerSecurityContext(t *testing.T) {
 		ReadOnlyRootFilesystem: &readOnlyRootFilesystemOverride,
 	}
 
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.SecurityContext = nonInitContainerSecurityContext
 	reaper.Spec.SchemaInitContainerConfig.SecurityContext = initContainerSecurityContext
@@ -296,7 +304,7 @@ func TestPodSecurityContext(t *testing.T) {
 	podSecurityContext := &corev1.PodSecurityContext{
 		RunAsUser: &runAsUser,
 	}
-	reaper := newReaperWithCassandraBackend()
+	reaper := newReaperWithCassandraBackend("service-test", "test-reaper")
 	reaper.Spec.Image = image
 	reaper.Spec.PodSecurityContext = podSecurityContext
 
@@ -307,9 +315,87 @@ func TestPodSecurityContext(t *testing.T) {
 	assert.True(t, same, "podSecurityContext expected at pod level")
 }
 
-func newReaperWithCassandraBackend() *api.Reaper {
-	namespace := "service-test"
-	reaperName := "test-reaper"
+func TestReaperDeploymentStrategy(t *testing.T) {
+	// Test to ensure that if we set DeploymentStrategy to Rolling then it gets set back to Recreate by reconcile()
+	// Reaper test resource
+	testReaper := newReaperWithCassandraBackend("default", "test-reaper")
+	runAsUser := int64(8675309)
+	testReaper.Spec.Image = "test/reaper:latest"
+	testReaper.Spec.PodSecurityContext = &corev1.PodSecurityContext{
+		RunAsUser: &runAsUser,
+	}
+	// Create CassDC
+	testCassDC := newCassDC("default", "dc1")
+
+	// Test Scheme
+	localSchemeBuilder := runtime.SchemeBuilder{
+		api.AddToScheme,
+		appsv1.AddToScheme,
+		cassdcapi.AddToScheme,
+	}
+	testScheme := runtime.NewScheme()
+	localSchemeBuilder.AddToScheme(testScheme)
+
+	// Mock client
+	k8sClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testCassDC.DeepCopy()).Build()
+
+	// Other fixtures
+	testSecretsmngr := NewSecretsManager()
+	testctx := context.Background()
+	testStatusManager := &status.StatusManager{Client: k8sClient}
+	testLogger := zap.New()
+
+	// Test reconcile deployment
+	r := defaultReconciler{
+		k8sClient,
+		testScheme,
+		testSecretsmngr,
+	}
+	req := ReaperRequest{
+		testReaper,
+		testLogger,
+		testStatusManager,
+	}
+	r.ReconcileDeployment(testctx, req)
+
+	// Ensure Reaper is deploying with RecreateStrategy
+	deploymentList := &appsv1.DeploymentList{}
+	if err := k8sClient.List(testctx, deploymentList, client.MatchingLabels{"app.kubernetes.io/managed-by": "reaper-operator"}); err != nil {
+		t.Log(err)
+		assert.FailNow(t, "Failed to get Reaper instance")
+	}
+	reaperDeployment := deploymentList.Items[0].DeepCopy()
+	assert.True(t, len(deploymentList.Items) == 1)                                               // Only one deployment should be observed
+	assert.True(t, reaperDeployment.Spec.Strategy.Type == appsv1.RecreateDeploymentStrategyType) // Deployment type is right.
+
+	// Change deploymentStrategy to RollingUpdate
+	reaperDeploymentPatch := client.MergeFrom(reaperDeployment.DeepCopy())
+	reaperDeployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+	}
+	if err := r.Patch(testctx, reaperDeployment, reaperDeploymentPatch); err != nil {
+		t.Log(err)
+		assert.FailNow(t, "Failed to patch deployment with appsv1.RecreateDeploymentStrategyType")
+	}
+
+	if err := k8sClient.List(testctx, deploymentList, client.MatchingLabels{"app.kubernetes.io/managed-by": "reaper-operator"}); err != nil {
+		t.Log(err)
+		assert.FailNow(t, "Failed to get Reaper Deployment")
+	}
+	assert.True(t, deploymentList.Items[0].Spec.Strategy.Type == appsv1.RollingUpdateDeploymentStrategyType)
+
+	// Reconcile - expect to see DeploymenStrategyType change back to Recreate
+	r.ReconcileDeployment(testctx, req)
+	if err := k8sClient.List(testctx, deploymentList, client.MatchingLabels{"app.kubernetes.io/managed-by": "reaper-operator"}); err != nil {
+		t.Log(err)
+		assert.FailNow(t, "Failed to get Reaper Deployment")
+	}
+	assert.True(t, len(deploymentList.Items) == 1) // Only one deployment should be observed
+	assert.True(t, deploymentList.Items[0].Spec.Strategy.Type == appsv1.RecreateDeploymentStrategyType)
+
+}
+
+func newReaperWithCassandraBackend(namespace string, reaperName string) *api.Reaper {
 	dcName := "dc1"
 
 	return &api.Reaper{
@@ -332,6 +418,22 @@ func newReaperWithCassandraBackend() *api.Reaper {
 					},
 				},
 			},
+		},
+	}
+}
+
+func newCassDC(namespace string, cassDCName string) cassdcapi.CassandraDatacenter {
+	return cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        cassDCName,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+		Spec: cassdcapi.CassandraDatacenterSpec{
+			ClusterName:   "name",
+			ServerType:    "cassandra",
+			ServerVersion: "3.11.7",
+			Size:          3,
 		},
 	}
 }


### PR DESCRIPTION
This PR:

1. Adds logic to reset the deployment strategy on the Reaper `Deployment` to recreate if it is ever set to rollingUpdate. 
2. Extends timeout on integration tests, which were previously failing.
3. Adds a unit test, supporting mocks and supporting resource creation functions for (1).
4. Makes existing test functions slightly more flexible.